### PR TITLE
[feat] support safe and kernel account types

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,16 @@ This repo has code examples on how to sponsor a mint for a [Knight Warriors](htt
 
 We currently have examples for the following SDKs, but contributions are always welcome! See [Contributing](https://github.com/coinbase/paymaster-bundler-examples/blob/master/CONTRIBUTING.md) for more details.
 
+### Supported SDKs
+
 - [Alchemy (aa-core)](https://github.com/coinbase/paymaster-bundler-examples/tree/master/examples/alchemy)
 - [Pimlico (permissionless.js)](https://github.com/coinbase/paymaster-bundler-examples/tree/master/examples/pimlico)
+
+### Supported Account Types
+
+- [SimpleAccount](https://github.com/eth-infinitism/account-abstraction/blob/develop/contracts/samples/SimpleAccount.sol) (default)
+- [Safe](https://safe.global/)
+- [Kernel](https://github.com/zerodevapp/kernel)
 
 ## Getting Started
 
@@ -28,12 +36,24 @@ git clone https://github.com/coinbase/paymaster-bundler-examples.git
   - Copy your RPC endpoint, and paste it into `config.json` as the `rpc_url` variable.
 
 - ### Add a signer
+
   You'll need to add a private key to initialize and sign for your [ERC-4337](https://www.erc4337.io/) smart contract account.
+
   - Since the NFT mint is free and gas will be sponsored by our Paymaster, you can use a new account without any funds.
   - You can create a new private key with [Foundry](https://book.getfoundry.sh/reference/cast/cast-wallet-new)
     - To install Foundry, run `curl -L https://foundry.paradigm.xyz | bash`
     - To generate a new key pair, run `cast wallet new`
   - Copy your private key, and paste it into `config.json` as the `private_key` variable
+
+- ### Optional: configure the smart account
+
+  - You can use a different smart account type by changing the `account_type` variable in `config.json`.
+    - Valid values: `simple`, `safe`, `kernel`
+  - Compatibility
+    | SDK | Simple | Safe | Kernel
+    | --- | --- | -- | --
+    | aa-core | ✅ | ❌ | ❌
+    | permissionless.js | ✅ | ✅ | ✅
 
 ### 3. Navigate to the directory of the SDK you want to run the example with.
 
@@ -68,4 +88,5 @@ Waiting for transaction...
 ```
 
 ### 7. Play around with our demo app
+
 If you'd like to see an example of an app sponsoring NFT mints in action, check out our demo app [here](https://buildonchainapps.xyz/paymaster-bundler).

--- a/config.json
+++ b/config.json
@@ -1,6 +1,7 @@
 {
     "rpc_url": "YOUR_RPC_URL",
     "private_key": "YOUR_PRIVATE_KEY",
+    "account_type": "simple",
     "contract_address": "0x66519FCAee1Ed65bc9e0aCc25cCD900668D3eD49",
     "function_name": "mintTo",
     "entry_point": "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"

--- a/examples/pimlico/src/account.js
+++ b/examples/pimlico/src/account.js
@@ -1,5 +1,6 @@
 
-import { privateKeyToSimpleSmartAccount } from "permissionless/accounts"
+import { privateKeyToSimpleSmartAccount, signerToSafeSmartAccount, signerToEcdsaKernelSmartAccount } from "permissionless/accounts"
+import { privateKeyToAccount } from "viem/accounts"
 import { http, createPublicClient } from 'viem'
 import config from '../../../config.json' assert { type: 'json' };
 
@@ -7,11 +8,40 @@ const publicClient = createPublicClient({
     transport: http(config.rpc_url),
 });
 
-// We use an EOA signer (private key) and a Simple Account for this example.
 // To customize the signer, see https://docs.pimlico.io/permissionless/reference/accounts/signerToSimpleSmartAccount
+const signer = privateKeyToAccount(config.private_key)
+
 // To use a different account, see https://docs.pimlico.io/permissionless/how-to/accounts/use-simple-account
-export const simpleAccount = await privateKeyToSimpleSmartAccount(publicClient, {
-    privateKey: config.private_key,
-    factoryAddress: "0x9406Cc6185a346906296840746125a0E44976454",
-    entryPoint: config.entry_point,
-})
+export const getAccount = async (type) => {
+    switch (type) {
+        case "simple":
+            // EOA signer (private key) and Simple Account
+            const simpleAccount = await privateKeyToSimpleSmartAccount(publicClient, {
+                privateKey: config.private_key,
+                factoryAddress: "0x9406Cc6185a346906296840746125a0E44976454",
+                entryPoint: config.entry_point,
+            })
+            return simpleAccount
+        case "safe":
+            // EOA signer (private key) and Safe
+            const safeAccount = await signerToSafeSmartAccount(publicClient, {
+                entryPoint: config.entry_point,
+                signer: signer,
+                safeVersion: "1.4.1",
+                // index: 0n, // optional
+                // address: "0x...", // optional, only if you are using an already created account
+            })
+            return safeAccount
+        case "kernel":
+             // EOA signer (private key) and Kernel
+            const kernelAccount = await signerToEcdsaKernelSmartAccount(publicClient, {
+                entryPoint: config.entry_point,
+                signer: signer,
+                // index: 0n, // optional
+                // address: "0x...", // optional, only if you are using an already created account
+            })
+            return kernelAccount
+        default:
+            throw new Error("Invalid account type in config.json")
+    }
+}


### PR DESCRIPTION
- `getAccount` function to initialize different types of smart accounts (simpleaccount, safe, and kernel)
- add `account_type` variable to configuration
- update readme to reflect this