### PR TITLE
chore: Update permissionless package examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-examples/*/node_modules/
+**/node_modules/
 examples/*/yarn-error.log
 
 .env

--- a/config.js
+++ b/config.js
@@ -9,5 +9,6 @@ export default {
     "account_type": process.env.ACCOUNT_TYPE || 'simple',
     "contract_address": "0x66519FCAee1Ed65bc9e0aCc25cCD900668D3eD49",
     "function_name": "mintTo",
-    "entry_point": "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789"
+    "entry_point": "0x5FF137D4b0FDCD49DcA30c7CF57E578a026d2789",
+    "entry_point_version": "0.6"
 }

--- a/examples/pimlico/package.json
+++ b/examples/pimlico/package.json
@@ -4,8 +4,8 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "permissionless": "^0.0.36",
-    "viem": "^2.7.13"
+    "permissionless": "^0.2.13",
+    "viem": "^2.20.0"
   },
   "scripts": {
     "dev": "node src/mint.js"

--- a/examples/pimlico/src/account.js
+++ b/examples/pimlico/src/account.js
@@ -1,42 +1,56 @@
 
-import { privateKeyToSimpleSmartAccount, signerToSafeSmartAccount, signerToEcdsaKernelSmartAccount } from "permissionless/accounts"
+import { toSimpleSmartAccount, toSafeSmartAccount, toEcdsaKernelSmartAccount } from "permissionless/accounts"
 import { privateKeyToAccount } from "viem/accounts"
 import { http, createPublicClient } from 'viem'
 import config from '../../../config.js';
+import { baseSepolia } from "viem/chains";
 
-const publicClient = createPublicClient({
+const client = createPublicClient({
+    chain: baseSepolia,
     transport: http(config.rpc_url),
 });
 
 // To customize the signer, see https://docs.pimlico.io/permissionless/reference/accounts/signerToSimpleSmartAccount
-const signer = privateKeyToAccount(config.private_key)
+const owner = privateKeyToAccount(config.private_key)
 
 // To use a different account, see https://docs.pimlico.io/permissionless/how-to/accounts/use-simple-account
 export const getAccount = async (type) => {
     switch (type) {
         case "simple":
             // EOA signer (private key) and Simple Account
-            const simpleAccount = await privateKeyToSimpleSmartAccount(publicClient, {
-                privateKey: config.private_key,
+            const simpleAccount = await toSimpleSmartAccount({
+                owner,
+                client,
                 factoryAddress: "0x9406Cc6185a346906296840746125a0E44976454",
-                entryPoint: config.entry_point,
+                entryPoint: {
+                    address: config.entry_point,
+                    version: config.entry_point_version,
+                },
             })
             return simpleAccount
         case "safe":
             // EOA signer (private key) and Safe
-            const safeAccount = await signerToSafeSmartAccount(publicClient, {
-                entryPoint: config.entry_point,
-                signer: signer,
-                safeVersion: "1.4.1",
+            const safeAccount = await toSafeSmartAccount({
+                owner,
+                client,
+                entryPoint: {
+                    address: config.entry_point,
+                    version: config.entry_point_version
+                },
+                version: "1.4.1",
                 // index: 0n, // optional
                 // address: "0x...", // optional, only if you are using an already created account
             })
             return safeAccount
         case "kernel":
              // EOA signer (private key) and Kernel
-            const kernelAccount = await signerToEcdsaKernelSmartAccount(publicClient, {
-                entryPoint: config.entry_point,
-                signer: signer,
+            const kernelAccount = await toEcdsaKernelSmartAccount({
+                owners: [owner],
+                client,
+                entryPoint: {
+                    address: config.entry_point,
+                    version: config.entry_point_version
+                },
                 // index: 0n, // optional
                 // address: "0x...", // optional, only if you are using an already created account
             })

--- a/examples/pimlico/src/mint.js
+++ b/examples/pimlico/src/mint.js
@@ -1,7 +1,7 @@
 import { encodeFunctionData, http } from 'viem'
 import { baseSepolia } from 'viem/chains'
 import { createSmartAccountClient } from 'permissionless'
-import { createPimlicoPaymasterClient } from "permissionless/clients/pimlico";
+import { createPimlicoClient } from "permissionless/clients/pimlico";
 import { getAccount } from './account.js';
 import { abi } from './abi.js';
 import config from '../../../config.js';
@@ -11,7 +11,7 @@ const rpcUrl = config.rpc_url
 const contractAddress = config.contract_address;
 
 // Create the Cloud Paymaster
-const cloudPaymaster = createPimlicoPaymasterClient({
+const cloudPaymaster = createPimlicoClient({
     chain: baseSepolia,
     transport: http(rpcUrl)
 })
@@ -26,9 +26,9 @@ const account = await getAccount(config.account_type).catch((error) => {
 const smartAccountClient = createSmartAccountClient({
     account,
     chain: baseSepolia,
-    transport: http(rpcUrl),
+    bundlerTransport: http(rpcUrl),
     // IMPORTANT: Set up the Cloud Paymaster to sponsor your transaction
-    sponsorUserOperation: cloudPaymaster.sponsorUserOperation,
+    paymaster: cloudPaymaster
 });
 
 // Encode the calldata
@@ -50,3 +50,4 @@ const txHash = await smartAccountClient.sendTransaction({
 
 console.log("\x1b[32m", `⛽ Successfully sponsored gas for ${config.function_name} transaction with Coinbase Developer Platform!`);
 console.log("\x1b[36m", `🔍 View on Etherscan: https://sepolia.basescan.org/tx/${txHash}`);
+process.exit(0)

--- a/examples/pimlico/yarn.lock
+++ b/examples/pimlico/yarn.lock
@@ -2,80 +2,84 @@
 # yarn lockfile v1
 
 
-"@adraffy/ens-normalize@1.10.0":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.10.0.tgz#d2a39395c587e092d77cbbc80acf956a54f38bf7"
-  integrity sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==
+"@adraffy/ens-normalize@1.11.0":
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz#42cc67c5baa407ac25059fcd7d405cc5ecdb0c33"
+  integrity sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==
 
-"@noble/curves@1.2.0", "@noble/curves@~1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.2.0.tgz#92d7e12e4e49b23105a2555c6984d41733d65c35"
-  integrity sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==
+"@noble/curves@1.6.0", "@noble/curves@^1.4.0", "@noble/curves@~1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@noble/curves/-/curves-1.6.0.tgz#be5296ebcd5a1730fccea4786d420f87abfeb40b"
+  integrity sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==
   dependencies:
-    "@noble/hashes" "1.3.2"
+    "@noble/hashes" "1.5.0"
 
-"@noble/hashes@1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.2.tgz#6f26dbc8fbc7205873ce3cee2f690eba0d421b39"
-  integrity sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==
+"@noble/hashes@1.5.0", "@noble/hashes@^1.4.0", "@noble/hashes@~1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.5.0.tgz#abadc5ca20332db2b1b2aa3e496e9af1213570b0"
+  integrity sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==
 
-"@noble/hashes@~1.3.0", "@noble/hashes@~1.3.2":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.3.3.tgz#39908da56a4adc270147bb07968bf3b16cfe1699"
-  integrity sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==
+"@scure/base@~1.1.7", "@scure/base@~1.1.8":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
+  integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==
 
-"@scure/base@~1.1.0", "@scure/base@~1.1.2":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.5.tgz#1d85d17269fe97694b9c592552dd9e5e33552157"
-  integrity sha512-Brj9FiG2W1MRQSTB212YVPRrcbjkv48FoZi/u4l/zds/ieRrqsh7aUf6CLwkAq61oKXr/ZlTzlY66gLIj3TFTQ==
-
-"@scure/bip32@1.3.2":
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.3.2.tgz#90e78c027d5e30f0b22c1f8d50ff12f3fb7559f8"
-  integrity sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==
+"@scure/bip32@1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.5.0.tgz#dd4a2e1b8a9da60e012e776d954c4186db6328e6"
+  integrity sha512-8EnFYkqEQdnkuGBVpCzKxyIwDCBLDVj3oiX0EKUFre/tOjL/Hqba1D6n/8RcmaQy4f95qQFrO2A8Sr6ybh4NRw==
   dependencies:
-    "@noble/curves" "~1.2.0"
-    "@noble/hashes" "~1.3.2"
-    "@scure/base" "~1.1.2"
+    "@noble/curves" "~1.6.0"
+    "@noble/hashes" "~1.5.0"
+    "@scure/base" "~1.1.7"
 
-"@scure/bip39@1.2.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.2.1.tgz#5cee8978656b272a917b7871c981e0541ad6ac2a"
-  integrity sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==
+"@scure/bip39@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.4.0.tgz#664d4f851564e2e1d4bffa0339f9546ea55960a6"
+  integrity sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==
   dependencies:
-    "@noble/hashes" "~1.3.0"
-    "@scure/base" "~1.1.0"
+    "@noble/hashes" "~1.5.0"
+    "@scure/base" "~1.1.8"
 
-abitype@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.0.tgz#237176dace81d90d018bebf3a45cb42f2a2d9e97"
-  integrity sha512-NMeMah//6bJ56H5XRj8QCV4AwuW6hB6zqz2LnhhLdcWVQOsXki6/Pn3APeqxCma62nXIcmZWdu1DlHWS74umVQ==
+abitype@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/abitype/-/abitype-1.0.6.tgz#76410903e1d88e34f1362746e2d407513c38565b"
+  integrity sha512-MMSqYh4+C/aVqI2RQaWqbvI4Kxo5cQV40WQ4QFtDnNzCkqChm8MuENhElmynZlO0qUy/ObkEUaXtKqYnx1Kp3A==
 
-isows@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.3.tgz#93c1cf0575daf56e7120bab5c8c448b0809d0d74"
-  integrity sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==
+isows@1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/isows/-/isows-1.0.6.tgz#0da29d706fa51551c663c627ace42769850f86e7"
+  integrity sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==
 
-permissionless@^0.0.36:
-  version "0.0.36"
-  resolved "https://registry.yarnpkg.com/permissionless/-/permissionless-0.0.36.tgz#f8faf65741ce4bc8f30a6c24d91137baa01b8c68"
-  integrity sha512-1/+N3zzFn2vjKZm6aol3eXsFO34d68/GAhKypq2iucFEPrgM5sdq3I5sOK+RrKuGIy8/Bix+IoHhtg0XCDPMOA==
+permissionless@^0.2.13:
+  version "0.2.13"
+  resolved "https://registry.yarnpkg.com/permissionless/-/permissionless-0.2.13.tgz#20cb982454a0f0e4933f7599e2fe4e9aa0df0caf"
+  integrity sha512-8VxJQP7ezwGKSdRvk/Q09i/+WtVxfdFuk3XEQSXyTbWVIxU9SRYPDLW2QuUlxiFsAOdDSRwuFGsrtevwBdcqdQ==
 
-viem@^2.7.13:
-  version "2.7.13"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-2.7.13.tgz#bf3f8e973f532f9f9c86c97b645ac8add740e1bd"
-  integrity sha512-NGWLEocRp2UTqGidzI9bnL9u6WHlG2ik7IwqXNe6/QC2dL6jE3Z1mUnUUVcSx71h81nx74EflD9ahtleK3RQdA==
+viem@^2.20.0:
+  version "2.21.38"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.21.38.tgz#607b25483b363c6f1a807f0fc39fb2f1e7d42d5a"
+  integrity sha512-MxhURy+F3eRtxkOoj7YdJTStJxqnWcP0MQZycVsxsVB4eZLKZPZfh7AgpfPjWHmPHmeVZcOqaGzFTmuPpqp06w==
   dependencies:
-    "@adraffy/ens-normalize" "1.10.0"
-    "@noble/curves" "1.2.0"
-    "@noble/hashes" "1.3.2"
-    "@scure/bip32" "1.3.2"
-    "@scure/bip39" "1.2.1"
-    abitype "1.0.0"
-    isows "1.0.3"
-    ws "8.13.0"
+    "@adraffy/ens-normalize" "1.11.0"
+    "@noble/curves" "1.6.0"
+    "@noble/hashes" "1.5.0"
+    "@scure/bip32" "1.5.0"
+    "@scure/bip39" "1.4.0"
+    abitype "1.0.6"
+    isows "1.0.6"
+    webauthn-p256 "0.0.10"
+    ws "8.18.0"
 
-ws@8.13.0:
-  version "8.13.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.13.0.tgz#9a9fb92f93cf41512a0735c8f4dd09b8a1211cd0"
-  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
+webauthn-p256@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/webauthn-p256/-/webauthn-p256-0.0.10.tgz#877e75abe8348d3e14485932968edf3325fd2fdd"
+  integrity sha512-EeYD+gmIT80YkSIDb2iWq0lq2zbHo1CxHlQTeJ+KkCILWpVy3zASH3ByD4bopzfk0uCwXxLqKGLqp2W4O28VFA==
+  dependencies:
+    "@noble/curves" "^1.4.0"
+    "@noble/hashes" "^1.4.0"
+
+ws@8.18.0:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==


### PR DESCRIPTION
Updated the example to use the latest version of permissionless.js, which has a couple of breaking changes