### PR TITLE
feat: Add safe eth and usdc transfer example

### DIFF
--- a/examples/pimlico/src/account.js
+++ b/examples/pimlico/src/account.js
@@ -30,7 +30,7 @@ export const getAccount = async (type) => {
         case "safe":
             // EOA signer (private key) and Safe
             const safeAccount = await toSafeSmartAccount({
-                owner,
+                owners: [owner],
                 client,
                 entryPoint: {
                     address: config.entry_point,

--- a/examples/safe/README.md
+++ b/examples/safe/README.md
@@ -1,0 +1,74 @@
+# Sponsored transactions with Safe wallet
+
+The code example in send.js shows you how to send eth from your Safe wallet to any address completely gasless using the Coinbase Developer Platform.
+
+## Prerequisites
+
+1. Create a Coinbase Developer Platform (CDP) account - https://portal.cdp.coinbase.com/
+2. Fetch your RPC URL from Onchain Tools -> Paymaster -> Configuration. RPC URL should look something like `https://api.developer.coinbase.com/rpc/v1/base/<some_token_id>`
+3. Have a Safe wallet (must be version 1.4.1+) - https://app.safe.global/
+
+
+## Deploying a new Safe wallet
+
+Unfortunately the Safe wallet UI does not allow you to create a wallet with the ability to have sponsored gas. Instead you'll need to create the wallet from the command line.
+
+1. Generate a new private key
+```
+cast wallet new
+```
+
+2. Update .env file
+```
+RPC_URL='https://api.developer.coinbase.com/rpc/v1/base/<some_token_id>'
+PRIVATE_KEY='0xabcd1123........'
+```
+
+3. Run deployment script
+```
+node deploy.js
+```
+
+Note - you didn't need to pay gas for this wallet deployment! The CDP paymaster also sponsors the wallet creation.
+
+
+4. (Optional) Add the newly deployed wallet to your Safe wallet UI (using Add Existing Safe Account). You have both the Safe wallet address and private key signer of the newly deployed Safe wallet.
+
+
+## Configure an existing Safe wallet
+
+If you already have an existing Safe wallet, you'll need to configure it to add the ERC-4337 module and fallback. You can read more [about it here.](https://docs.safe.global/advanced/erc-4337/4337-safe)
+
+1. Add a private key signer to your Safe wallet (you can skip this step if you already have a private key signer).
+2. Add the ERC-4337 module
+    - Apps -> Transaction Builder -> New Transaction
+    - Address: `0x29fcB43b46531BcA003ddC8FCB67FFE91900C762` (this is actually just used to autofill the ABI for you)
+    - ABI: (let it auto fill)
+    - To Address: your Safe wallet address
+    - Contract Method Selector: `enableModule`
+    - Module: `0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226`
+3. Add the ERC-4337 fallback
+    - Apps -> Transaction Builder -> New Transaction
+    - Address: `0x29fcB43b46531BcA003ddC8FCB67FFE91900C762` (this is actually just used to autofill the ABI for you)
+    - ABI: (let it auto fill)
+    - To Address: your Safe wallet address
+    - Contract Method Selector: `setFallBackHandler`
+    - Handler: `0x75cf11467937ce3F2f357CE24ffc3DBF8fD5c226`
+
+Note - You can batch these two transactions together
+
+Finally, update your .env file in this directory
+```
+RPC_URL='https://api.developer.coinbase.com/rpc/v1/base/<some_token_id>'
+PRIVATE_KEY='0xabcd1123........'
+```
+
+## Profit!
+
+Next time you need to send eth, usdc, or make any other contract call, you can do it completely gasless using
+
+```
+node send.js
+```
+
+By default the code in send.js just does a simple eth transfer. You'll have to edit it to suit your needs.

--- a/examples/safe/deploy.js
+++ b/examples/safe/deploy.js
@@ -1,0 +1,56 @@
+import 'dotenv/config'
+import { createSmartAccountClient } from "permissionless"
+import { toSafeSmartAccount } from "permissionless/accounts"
+import { createPimlicoClient } from "permissionless/clients/pimlico"
+import { createPublicClient, getContract, http, parseEther } from "viem"
+import { privateKeyToAccount } from "viem/accounts"
+import { entryPoint07Address } from "viem/account-abstraction"
+import { base } from "viem/chains"
+
+const rpcUrl = process.env.RPC_URL;
+const privateKey = process.env.PRIVATE_KEY;
+
+export const publicClient = createPublicClient({
+	chain: base,
+	transport: http(rpcUrl),
+})
+ 
+export const paymasterClient = createPimlicoClient({
+	transport: http(rpcUrl),
+	entryPoint: {
+		address: entryPoint07Address,
+		version: "0.7",
+	},
+})
+
+// The private key signer of your Safe wallet. Generate a new one using "cast wallet new"
+const owner = privateKeyToAccount(privateKey)
+
+const safeAccount = await toSafeSmartAccount({
+	client: publicClient,
+	entryPoint: {
+		address: entryPoint07Address,
+		version: "0.7",
+	},
+	owners: [owner],
+	version: "1.4.1",
+})
+
+const smartAccountClient = createSmartAccountClient({
+	account: safeAccount,
+	chain: base,
+	paymaster: paymasterClient,
+	bundlerTransport: http(rpcUrl),
+})
+
+console.log(`🚀 Deploying your new Safe wallet to address: https://basescan.org/address/${smartAccountClient.account.address}`)
+
+// This is a new wallet with nothing to send, so it just needs some dummy transaction data
+const txHash = await smartAccountClient.sendTransaction({
+	to: "0x0000000000000000000000000000000000000000",
+	value: 0n,
+	data: "0x0",
+})
+
+console.log(`✅ Wallet deploy completed: https://basescan.org/tx/${txHash}`)
+process.exit(0)

--- a/examples/safe/package-lock.json
+++ b/examples/safe/package-lock.json
@@ -1,0 +1,451 @@
+{
+  "name": "safe",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "safe",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.4.7",
+        "permissionless": "^0.2.23",
+        "yargs": "^17.7.2"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.11.0.tgz",
+      "integrity": "sha512-/3DDPKHqqIqxUULp8yP4zODUY1i+2xvVWsv8A79xGWdCAG+8sb0hRh0Rk2QyOJUnnbyPUAZYcpBuRe3nS2OIUg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.7.0.tgz",
+      "integrity": "sha512-UTMhXK9SeDhFJVrHeUJ5uZlI6ajXg10O6Ddocf9S6GjbSBVZsJo88HzKwXznNfGpMTRDyJkqMjNDPYgf0qFWnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "1.6.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.0.tgz",
+      "integrity": "sha512-YUULf0Uk4/mAA89w+k3+yUYh6NrEvxZa5T6SY3wlMvE2chHkxFUUIDI8/XW1QSC357iA5pSnqt7XEhvFOqmDyQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.6.1.tgz",
+      "integrity": "sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.1.tgz",
+      "integrity": "sha512-DGmGtC8Tt63J5GfHgfl5CuAXh96VF/LD8K9Hr/Gv0J2lAoRGlPOMpqMpMbCTOoOJMZCk2Xt+DskdDyn6dEFdzQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.6.0.tgz",
+      "integrity": "sha512-82q1QfklrUUdXJzjuRU7iG7D7XiFx5PHYVS0+oeNKhyDLT7WPqs6pBcM2W5ZdwOwKCwoE1Vy1se+DHjcXwCYnA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/curves": "~1.7.0",
+        "@noble/hashes": "~1.6.0",
+        "@scure/base": "~1.2.1"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.5.0.tgz",
+      "integrity": "sha512-Dop+ASYhnrwm9+HA/HwXg7j2ZqM6yk2fyLWb5znexjctFY3+E+eU8cIWI0Pql0Qx4hPZCijlGq4OL71g+Uz30A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "~1.6.0",
+        "@scure/base": "~1.2.1"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/abitype": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/abitype/-/abitype-1.0.7.tgz",
+      "integrity": "sha512-ZfYYSktDQUwc2eduYu8C4wOs+RDPmnRYMh7zNfzeMtGGgb0U+6tLGjixUic6mXf5xKKCcgT5Qp6cv39tOARVFw==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/wevm"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4",
+        "zod": "^3 >=3.22.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isows": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
+      "integrity": "sha512-lPHCayd40oW98/I0uvgaHKWCSvkzY27LjWLbtzOm64yQ+G3Q5npjjbdppU65iZXkK1Zt+kH9pfegli0AYfwYYw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/ox": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.1.2.tgz",
+      "integrity": "sha512-ak/8K0Rtphg9vnRJlbOdaX9R7cmxD2MiSthjWGaQdMk3D7hrAlDoM+6Lxn7hN52Za3vrXfZ7enfke/5WjolDww==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/permissionless": {
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/permissionless/-/permissionless-0.2.23.tgz",
+      "integrity": "sha512-J/Z8Tvgv/FKcbu9DMDYu/QLkssnlOAbQ6yXPqKsRywdB+x4FT5PDHVkwBdK46t6QnDy8r4zU9G1EmlTSmZA2kA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "viem": "^2.21.54",
+        "webauthn-p256": "0.0.10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/viem": {
+      "version": "2.21.55",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.55.tgz",
+      "integrity": "sha512-PgXew7C11cAuEtOSgRyQx2kJxEOPUwIwZA9dMglRByqJuFVA7wSGZZOOo/93iylAA8E15bEdqy9xulU3oKZ70Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/curves": "1.7.0",
+        "@noble/hashes": "1.6.1",
+        "@scure/bip32": "1.6.0",
+        "@scure/bip39": "1.5.0",
+        "abitype": "1.0.7",
+        "isows": "1.0.6",
+        "ox": "0.1.2",
+        "webauthn-p256": "0.0.10",
+        "ws": "8.18.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.4"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webauthn-p256": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/webauthn-p256/-/webauthn-p256-0.0.10.tgz",
+      "integrity": "sha512-EeYD+gmIT80YkSIDb2iWq0lq2zbHo1CxHlQTeJ+KkCILWpVy3zASH3ByD4bopzfk0uCwXxLqKGLqp2W4O28VFA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    }
+  }
+}

--- a/examples/safe/package.json
+++ b/examples/safe/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "safe",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "type": "module",
+  "dependencies": {
+    "dotenv": "^16.4.7",
+    "permissionless": "^0.2.23",
+    "yargs": "^17.7.2"
+  }
+}

--- a/examples/safe/send.js
+++ b/examples/safe/send.js
@@ -1,0 +1,128 @@
+import 'dotenv/config'
+import yargs from 'yargs'
+import { hideBin } from 'yargs/helpers'
+import { createSmartAccountClient } from "permissionless"
+import { toSafeSmartAccount } from "permissionless/accounts"
+import { createPimlicoClient } from "permissionless/clients/pimlico"
+import { createPublicClient, getContract, http, isAddress, parseEther } from "viem"
+import { privateKeyToAccount } from "viem/accounts"
+import { entryPoint07Address } from "viem/account-abstraction"
+import { base } from "viem/chains"
+
+const rpcUrl = process.env.RPC_URL;
+const privateKey = process.env.PRIVATE_KEY;
+const supportedCurrencies = ['ETH', 'USDC']
+
+const argv = yargs(hideBin(process.argv))
+  .option('currency', {
+    description: 'Token currency (ETH, USDC, etc)',
+    type: 'string',
+    demandOption: true,
+  })
+  .option('from', {
+    description: 'Address of your Safe wallet',
+    type: 'string',
+    demandOption: true,
+  })
+  .option('to', {
+    description: 'Address to send currency to',
+    type: 'string',
+    demandOption: true,
+  })
+  .option('amount', {
+    description: 'Amount of currency to send',
+    type: 'number',
+    demandOption: true,
+  })
+  .check((argv) => {
+    if (!isAddress(argv.to)) {
+        throw new Error(`Error: "${argv.to}" is not a valid Ethereum address`)
+    }
+    if (!isAddress(argv.from)) {
+        throw new Error(`Error: "${argv.from}" is not a valid Ethereum address`)
+    }
+    if (!supportedCurrencies.includes(argv.currency.toUpperCase())) {
+        throw new Error(`Error: "${argv.currency} is not supported`)
+    }
+    return true
+  })
+  .argv
+
+const {currency, to, from, amount} = argv
+
+
+export const publicClient = createPublicClient({
+	chain: base,
+	transport: http(rpcUrl),
+})
+ 
+export const paymasterClient = createPimlicoClient({
+	transport: http(rpcUrl),
+	entryPoint: {
+		address: entryPoint07Address,
+		version: "0.7",
+	},
+})
+
+const owner = privateKeyToAccount(privateKey)
+
+const safeAccount = await toSafeSmartAccount({
+	client: publicClient,
+	entryPoint: {
+		address: entryPoint07Address,
+		version: "0.7",
+	},
+	owners: [owner],
+	version: "1.4.1",
+    address: from
+})
+
+const smartAccountClient = createSmartAccountClient({
+	account: safeAccount,
+	chain: base,
+	paymaster: paymasterClient,
+	bundlerTransport: http(rpcUrl),
+})
+
+console.log(`🚀 Sending ${argv.currency} to address: https://basescan.org/address/${smartAccountClient.account.address}`)
+
+if (currency.toUpperCase() == 'ETH') {
+    const amountInWei = amount * 10**18
+    const txHash = await smartAccountClient.sendTransaction({
+        to: to,
+        value: amountInWei,
+    })
+    console.log(`✅ Eth sent: https://basescan.org/tx/${txHash}`)
+}
+
+if (currency.toUpperCase() == 'USDC') {
+    // USDC has 6 decimals
+    const amountInDecimals = amount * 10**6
+    const usdcAddress = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+    const usdcABI = [{
+        "name": "transfer",
+        "type": "function",
+        "inputs": [
+            {"name": "to", "type": "address"},
+            {"name": "amount", "type": "uint256"}
+        ],
+        "outputs": [{"type": "bool"}]
+    }]
+
+    const txHash = await smartAccountClient.sendTransaction({
+        calls: [
+            {
+                abi: usdcABI,
+                functionName: "transfer",
+                to: usdcAddress,
+                args: [to, amountInDecimals]
+            }
+        ]
+    })
+
+    console.log(`✅ Eth sent: https://basescan.org/tx/${txHash}`)
+}
+
+
+process.exit(0)
+


### PR DESCRIPTION
You can send usdc and eth from your safe wallet completely gasless using this example by running this command below

```
node send.js --currency usdc --from 0xa81476d5eAA92DA327798936254e88A739361534 --to 0x1c2BEf880dfC7372D148EEe02bE168ecd2Ff5c50 --amount 1
```
